### PR TITLE
Create a custom mailer to send Twilio SMS Text messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'sass-rails', '>= 6'
 gem 'scenic'
 gem 'sentry-raven'
 gem 'textacular', '~> 5.0'
+gem 'twilio-ruby'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jwt (2.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.7.0)
@@ -291,6 +292,10 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
+    twilio-ruby (5.34.0)
+      faraday (>= 0.9, < 2.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     warden (1.2.8)
@@ -350,6 +355,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   textacular (~> 5.0)
   timecop
+  twilio-ruby
   tzinfo-data
   web-console (>= 3.3.0)
   webmock

--- a/app/controllers/aid_applications/edits_controller.rb
+++ b/app/controllers/aid_applications/edits_controller.rb
@@ -18,6 +18,10 @@ module AidApplications
 
       if params[:form_action] == 'submit'
         @aid_application.save_and_submit(submitter: current_user)
+
+        if @aid_application.errors.empty?
+          ApplicationTexter.basic_message(to: @aid_application.phone_number, body: "Your Application Number is #{@aid_application.application_number}").deliver_now
+        end
       else
         @aid_application.save
       end

--- a/app/lib/phone_number_formatter.rb
+++ b/app/lib/phone_number_formatter.rb
@@ -1,0 +1,12 @@
+module PhoneNumberFormatter
+  def self.format(phone_number_string)
+    return phone_number_string unless phone_number_string.present?
+
+    cleaned_string = phone_number_string.gsub(/\D+/, "")
+    if (cleaned_string.length == 11) && (cleaned_string[0] == '1')
+      "+" + cleaned_string
+    elsif cleaned_string.length == 10
+      "+1" + cleaned_string
+    end
+  end
+end

--- a/app/mailers/application_emailer.rb
+++ b/app/mailers/application_emailer.rb
@@ -1,4 +1,4 @@
-class ApplicationMailer < ActionMailer::Base
+class ApplicationEmailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'
 

--- a/app/mailers/application_texter.rb
+++ b/app/mailers/application_texter.rb
@@ -1,0 +1,22 @@
+class ApplicationTexter < ActionMailer::Base
+  default from: -> { deliver_with_twilio? ? nil : 'SMS' },
+          subject: '',
+          delivery_method: -> { deliver_with_twilio? ? :twilio_sms : nil },
+          delivery_method_options: {
+            messaging_service_sid: Rails.application.secrets.twilio_messaging_service_sid,
+          }
+
+  def basic_message(to:, body:)
+    phone_number = PhoneNumberFormatter.format(to)
+
+    mail(to: phone_number, body: body) do |format|
+      format.text { render plain: body }
+    end
+  end
+
+  private
+
+  def deliver_with_twilio?
+    !Rails.application.config.action_mailer.delivery_method.in?([:letter_opener, :test])
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ApplicationEmailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/initializers/twilio.rb
+++ b/config/initializers/twilio.rb
@@ -1,0 +1,4 @@
+Twilio.configure do |config|
+  config.account_sid = Rails.application.secrets.twilio_account_sid
+  config.auth_token = Rails.application.secrets.twilio_auth_token
+end

--- a/config/initializers/twilio_sms_delivery.rb
+++ b/config/initializers/twilio_sms_delivery.rb
@@ -1,0 +1,24 @@
+require Rails.application.root.join('app', 'lib', 'phone_number_formatter')
+
+module Mail
+  class TwilioSmsDelivery
+    attr_reader :response
+
+    def initialize(options)
+      @options = options
+    end
+
+    def deliver!(mail)
+      twilio_client = Twilio::REST::Client.new
+
+      @response = twilio_client.messages.create(
+        @options.merge(
+          to: PhoneNumberFormatter.format(Array(mail.to).first),
+          body: mail.body.raw_source
+        )
+      )
+    end
+  end
+end
+
+ActionMailer::Base.add_delivery_method :twilio_sms, Mail::TwilioSmsDelivery

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -2,6 +2,9 @@ defaults: &defaults
   secret_key_base: fc10280147ee153d098675a4275356656728b8606b6c2c8e9070f6c4af3a27885d66592af99cfc71ff6b76c1734c0b5044ad2fed5d1a470a0ce5258942bfb31d
   host: <%= ENV.fetch('HOST', 'localhost:3000') %>
   sendgrid_api_key: <%= ENV['SENDGRID_API_KEY'] %>
+  twilio_account_sid: <%= ENV['TWILIO_ACCOUNT_SID'] %>
+  twilio_auth_token: <%= ENV['TWILIO_AUTH_TOKEN'] %>
+  twilio_messaging_service_sid: <%= ENV['TWILIO_MESSAGING_SERVICE_SID'] %>
 
 deployment: &deployment
   <<: *defaults

--- a/spec/lib/phone_number_formatter_spec.rb
+++ b/spec/lib/phone_number_formatter_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe PhoneNumberFormatter do
+  describe '#format' do
+    it 'adds a +1 to the front of a 10-digit number' do
+      expect(PhoneNumberFormatter.format('5555555555')).to eq '+15555555555'
+    end
+
+    it 'adds a + in front of an 11-digit number' do
+      expect(PhoneNumberFormatter.format('15555555555')).to eq '+15555555555'
+    end
+  end
+end

--- a/spec/mailers/application_texter_spec.rb
+++ b/spec/mailers/application_texter_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe ApplicationTexter do
+  let(:application_delivery_method) { :smtp }
+  let(:twilio_client) { instance_double(Twilio::REST::Client, messages: twilio_messages) }
+  let(:twilio_response) { OpenStruct.new(sid: "12345") }
+  let(:twilio_messages) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList, create: twilio_response) }
+
+  around do |example|
+    original_delivery_method = Rails.application.config.action_mailer.delivery_method
+    Rails.application.config.action_mailer.delivery_method = application_delivery_method
+    example.call
+    Rails.application.config.action_mailer.delivery_method = original_delivery_method
+  end
+
+  before do
+    allow(Twilio::REST::Client).to receive(:new).and_return(twilio_client)
+  end
+
+  context 'when the default Rails delivery method is SMTP' do
+    it 'uses the Twilio SMS delivery method' do
+      ApplicationTexter.basic_message(to: "123-456-7890", body: "hello").deliver_now
+
+      expect(twilio_messages).to have_received(:create).with(
+        messaging_service_sid: Rails.application.secrets.twilio_messaging_service_sid,
+        to: '+11234567890',
+        body: 'hello'
+      )
+    end
+  end
+
+  context 'when the default Rails delivery method is test' do
+    let(:application_delivery_method) { :test }
+
+    it 'uses test delivery method' do
+      ApplicationTexter.basic_message(to: "123-456-7890", body: "hello").deliver_now
+
+      expect(twilio_messages).not_to have_received(:create)
+      expect(ActionMailer::Base.deliveries).not_to be_empty
+    end
+  end
+
+  context 'when the default Rails delivery method is letter_opener' do
+    let(:application_delivery_method) { :letter_opener }
+
+    it 'does not send through Twilio' do
+      ApplicationTexter.basic_message(to: "123-456-7890", body: "hello").deliver_now
+
+      expect(twilio_messages).not_to have_received(:create)
+    end
+  end
+end

--- a/spec/support/capybara_email.rb
+++ b/spec/support/capybara_email.rb
@@ -1,5 +1,13 @@
 require 'capybara/email/rspec'
 
+module Capybara::Email::DSL
+  def open_sms(from)
+    open_email PhoneNumberFormatter.format(from)
+  end
+
+  alias current_sms current_email
+end
+
 RSpec.configure do |config|
   config.include Capybara::Email::DSL
 

--- a/spec/system/start_aid_application_spec.rb
+++ b/spec/system/start_aid_application_spec.rb
@@ -107,5 +107,8 @@ describe 'Start aid application', type: :system do
                         sexual_orientation: "Qweer",
                         gender: nil
                       )
+
+    open_sms aid_application.phone_number
+    expect(current_sms).to have_content aid_application.application_number
   end
 end


### PR DESCRIPTION
This creates a custom ActionMailer delivery method that replaces SMTP with Twilio's API Client. The goal here is to create symmetry between the process of sending an email and sending an SMS message. 