### PR TITLE
Root redirects to sign in page if the user is not signed in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,11 +42,20 @@ class ApplicationController < ActionController::Base
 
     if stored_location.present?
       stored_location
+    else
+      redirect_to_organization_home_page(user)
+    end
+  end
+
+  def redirect_to_organization_home_page(user)
+    if user.assister?
+      organization_aid_applications_path(user.organization)
     elsif user.organization.present?
       organization_path(user.organization)
     else
       organizations_path
     end
   end
+  helper_method :redirect_to_organization_home_page
 end
 

--- a/app/controllers/hello_worlds_controller.rb
+++ b/app/controllers/hello_worlds_controller.rb
@@ -1,4 +1,7 @@
 class HelloWorldsController < ApplicationController
+  before_action :authenticate_user!, only: :show
+
   def show
+    redirect_to redirect_to_organization_home_page(current_user)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,4 +112,8 @@ class User < ApplicationRecord
   def inactive_message
     deactivated_at.present? ? 'Account has been deactivated' : super
   end
+
+  def assister?
+    !admin && !supervisor
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,7 @@
 <% content = capture_form do |f| %>
+  <h2>Sign in</h2>
   <%= f.cfa_input_field :email, "Email Address", classes: ["form-width--long"] %>
-  <%= f.cfa_input_field(:password, "Password", type: "password", classes: ["form-width--med"]) %>
+  <%= f.cfa_input_field(:password, "Password", type: "password", classes: ["form-width--long"]) %>
   <p class="text--help">
     <%= link_to("Forgot your password?", new_password_path(resource_name), class: "link--subtle") %>
   </p>
@@ -13,7 +14,7 @@
 <%= render 'shared/form_card',
            form_resource: resource,
            form_options: { url: session_path(resource_name) },
-           title: "Sign in",
+           title: "Disaster Assistance For Immigrants",
            content: content,
            footer: footer
 %>

--- a/app/views/hello_worlds/show.html.erb
+++ b/app/views/hello_worlds/show.html.erb
@@ -1,1 +1,0 @@
-<h1>Hello World!</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Dafi</title>
+    <title>DRAI Portal</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/shared/_footer.erb
+++ b/app/views/shared/_footer.erb
@@ -2,7 +2,7 @@
   <div class="grid">
     <div class="main-footer__legal">
       <div class="grid__item width-two-thirds">
-        <p>DAFI is a service delivered by Code for America on behalf of the people of California.</p>
+        <p>DRAI Portal is a service delivered by Code for America on behalf of the people of California.</p>
       </div>
     </div>
 

--- a/app/views/shared/_form_card.erb
+++ b/app/views/shared/_form_card.erb
@@ -1,7 +1,7 @@
 <div class="grid__item width-two-thirds shift-one-sixth">
   <div class="form-card">
     <header class="form-card__header">
-      <h1 class="form-card__title"><%= title %></h1>
+      <h1><%= title %></h1>
     </header>
 
     <%= form_for(form_resource, form_options.merge(builder: DafiFormBuilder)) do |f| %>

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -3,7 +3,7 @@
     <div class="toolbar">
       <div class="toolbar__left">
         <div class="main-header__title">
-          <%= link_to "DAFI", root_path, class: "main-header__no-logo" %>
+          <%= link_to "DRAI Portal", root_path, class: "main-header__no-logo" %>
         </div>
       </div>
       <div class="toolbar__right">

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,4 +67,21 @@ RSpec.describe User, type: :model do
       expect(user.active_for_authentication?).to eq false
     end
   end
+
+  describe '#assister?' do
+    it 'is false is the user is an admin' do
+      user = build :user, admin: true, organization: build(:organization)
+      expect(user.assister?).to eq false
+    end
+
+    it 'is false is the user is an supervisor' do
+      user = build :user, supervisor: true, organization: build(:organization)
+      expect(user.assister?).to eq false
+    end
+
+    it 'is true is the user is not an admin and not a supervisor' do
+      user = build :user, admin: false, supervisor: false, organization: build(:organization)
+      expect(user.assister?).to eq true
+    end
+  end
 end

--- a/spec/system/approve_aid_application_spec.rb
+++ b/spec/system/approve_aid_application_spec.rb
@@ -13,7 +13,6 @@ describe 'Approve aid application', type: :system do
   specify do
     sign_in supervisor
     visit root_path
-    click_on assister.organization.name
     click_on 'Applications'
 
     within '.searchbar' do

--- a/spec/system/change_password_spec.rb
+++ b/spec/system/change_password_spec.rb
@@ -5,7 +5,6 @@ describe 'Password reset', type: :system do
 
   it 'allows a user to reset their password' do
     visit root_path
-    click_on 'Sign in'
 
     within 'form' do
       fill_in 'Email', with: user.email
@@ -25,8 +24,6 @@ describe 'Password reset', type: :system do
 
     click_on 'Sign out', match: :first
 
-    click_on 'Sign in'
-
     within 'form' do
       fill_in 'Email', with: user.email
       fill_in 'Password', with: 'Qwerty!2'
@@ -38,7 +35,6 @@ describe 'Password reset', type: :system do
 
   it 'allows a user to reset their password' do
     visit root_path
-    click_on 'Sign in'
     click_on 'Forgot your password?'
 
     fill_in 'Email', with: user.email

--- a/spec/system/deactivate_user_spec.rb
+++ b/spec/system/deactivate_user_spec.rb
@@ -17,7 +17,6 @@ describe 'Deactivate Users', type: :system do
     Capybara.using_session(:supervisor) do
       sign_in supervisor
       visit root_path
-      click_on organization.name
 
       click_on 'Assisters'
 
@@ -55,8 +54,6 @@ describe 'Deactivate Users', type: :system do
     Capybara.using_session(:assister) do
       visit root_path
       expect(page).not_to have_link 'Sign out'
-
-      click_on 'Sign in', match: :first
 
       within 'form' do
         fill_in 'Email', with: assister.email

--- a/spec/system/hello_world_spec.rb
+++ b/spec/system/hello_world_spec.rb
@@ -1,8 +1,0 @@
-require 'rails_helper'
-
-describe 'Hello World' do
-  specify do
-    visit root_path
-    expect(page).to have_content "Hello World!"
-  end
-end

--- a/spec/system/invite_new_users_spec.rb
+++ b/spec/system/invite_new_users_spec.rb
@@ -69,7 +69,6 @@ describe 'Account invitations', type: :system do
   it 'can be initiated by a Supervisor' do
     sign_in supervisor
     visit root_path
-    click_on supervisor.organization.name
 
     click_on 'Assisters'
     click_on 'Add new assister'
@@ -93,7 +92,6 @@ describe 'Account invitations', type: :system do
 
     sign_in assister
     visit root_path
-    click_on assister.organization.name
 
     click_on 'Assisters'
     expect(page).not_to have_link 'Add new assister'

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe 'Search in admin panel', type: :system do
   it 'assisters can search for applications' do
     sign_in assister
     visit root_path
-    click_on assister.organization.name
-    click_on 'Applications'
 
     within '.searchbar' do
       fill_in "term", with: aid_application.name

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe 'Home page redirects to the signin page' do
+  context 'assister' do
+    let!(:assister) { create(:assister, email: 'assister@foodbank.org', password: 'Qwerty!2', admin: false, supervisor: false) }
+
+    it 'after sign in redirects to the aid applicants page for their organization' do
+      visit root_path
+      expect(page).to have_content "Sign in"
+      expect(page).to have_content "Disaster Assistance For Immigrants"
+
+      fill_in 'Email Address', with: 'assister@foodbank.org'
+      fill_in 'Password', with: 'Qwerty!2'
+      click_button 'Sign in'
+
+      expect(page).to have_content "Add new application"
+    end
+  end
+
+  context 'supervisor' do
+    let!(:supervisor) { create(:supervisor, email: 'supervisor@foodbank.org', password: 'Qwerty!2', admin: false, supervisor: true) }
+
+    it 'after sign in redirects to their organization page' do
+      visit root_path
+      expect(page).to have_content "Sign in"
+      expect(page).to have_content "Disaster Assistance For Immigrants"
+
+      fill_in 'Email Address', with: 'supervisor@foodbank.org'
+      fill_in 'Password', with: 'Qwerty!2'
+      click_button 'Sign in'
+
+      expect(page).to have_content "Submitted Apps"
+    end
+  end
+
+  context 'user visits sign in url directly' do
+    let!(:supervisor) { create(:supervisor, email: 'supervisor@foodbank.org', password: 'Qwerty!2', admin: false, supervisor: true) }
+
+    it 'redirects to their organization page after sign in' do
+      visit new_user_session_path
+
+      expect(page).to have_content "Sign in"
+      expect(page).to have_content "Disaster Assistance For Immigrants"
+
+      fill_in 'Email Address', with: 'supervisor@foodbank.org'
+      fill_in 'Password', with: 'Qwerty!2'
+      click_button 'Sign in'
+
+      expect(page).to have_content "Submitted Apps"
+    end
+  end
+end

--- a/spec/system/start_aid_application_spec.rb
+++ b/spec/system/start_aid_application_spec.rb
@@ -7,9 +7,6 @@ describe 'Start aid application', type: :system, js: true do
     sign_in assister
 
     visit root_path
-    click_on assister.organization.name
-
-    click_on "Applications"
     click_on "Add new application"
 
     expect(page).to have_content "DRAI application"


### PR DESCRIPTION
- it redirects to the assister organization page if the user is a signed in assister
- it redirects to the supervisor organization page if the user is a signed in supervisor

Co-authored-by: Anule Ndukwu <anule@codeforamerica.org>