### PR TITLE
Send application numbers as a `perform_later` job instead of `perform_now`

### DIFF
--- a/app/controllers/aid_applications/applicants_controller.rb
+++ b/app/controllers/aid_applications/applicants_controller.rb
@@ -19,7 +19,7 @@ module AidApplications
         @aid_application.save_and_submit(submitter: current_user)
 
         if @aid_application.errors.empty?
-          SendApplicationNumberNotificationJob.perform_now(aid_application: @aid_application)
+          SendApplicationNumberNotificationJob.perform_later(aid_application: @aid_application)
         end
       elsif params[:form_action] == 'allow_mailing_address'
         @aid_application.allow_mailing_address = true

--- a/spec/system/start_aid_application_spec.rb
+++ b/spec/system/start_aid_application_spec.rb
@@ -87,7 +87,9 @@ describe 'Start aid application', type: :system do
       check "Yes"
     end
 
-    click_on 'Submit'
+    perform_enqueued_jobs do
+      click_on 'Submit'
+    end
 
     expect(page).to have_content 'Application submitted'
     expect(page).to have_content /APP-/


### PR DESCRIPTION

Co-authored-by: Whitney Schaefer <whitney.schaefer@gmail.com>