### PR TITLE
Increase Session Timeout to 30 minutes

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -176,7 +176,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 15.minutes
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/system/session_timeout_spec.rb
+++ b/spec/system/session_timeout_spec.rb
@@ -7,15 +7,15 @@ describe 'Session timeout' do
     sign_in assister
     visit root_path
 
-    Timecop.travel 14.minutes
+    Timecop.travel 29.minutes
     visit root_path
     expect(page).to have_link 'Sign out'
 
-    Timecop.travel 14.minutes
+    Timecop.travel 29.minutes
     visit root_path
     expect(page).to have_link 'Sign out'
 
-    Timecop.travel 16.minutes
+    Timecop.travel 31.minutes
     visit root_path
     expect(page).not_to have_link 'Sign out'
     expect(page).to have_content 'Your session expired. Please sign in again to continue.'


### PR DESCRIPTION
To prevent assisters from being signed-out in the middle of completing an application form