### PR TITLE
Deduplicate applications during approval

### DIFF
--- a/app/controllers/aid_applications/approvals_controller.rb
+++ b/app/controllers/aid_applications/approvals_controller.rb
@@ -8,12 +8,18 @@ module AidApplications
 
     def update
       @aid_application = current_aid_application
-      @aid_application.save_and_approve(approver: current_user)
+      app_is_duplicate = AidApplication.matching_approved_apps(@aid_application).any?
 
-      if params['form_action'] == 'approve_and_exit'
-        respond_with @aid_application, location: organization_dashboard_path(current_organization), notice: "#{@aid_application.application_number} has been approved."
+      if app_is_duplicate
+        respond_with @aid_application, location: organization_aid_application_duplicate_path(current_organization, @aid_application)
       else
-        respond_with @aid_application, location: edit_organization_aid_application_disbursement_path(@aid_application.organization, @aid_application)
+        @aid_application.save_and_approve(approver: current_user)
+
+        if params['form_action'] == 'approve_and_exit'
+          respond_with @aid_application, location: organization_dashboard_path(current_organization), notice: "#{@aid_application.application_number} has been approved."
+        else
+          respond_with @aid_application, location: edit_organization_aid_application_disbursement_path(@aid_application.organization, @aid_application)
+        end
       end
     end
   end

--- a/app/models/aid_application.rb
+++ b/app/models/aid_application.rb
@@ -231,6 +231,10 @@ class AidApplication < ApplicationRecord
       )
   end
 
+  scope :matching_approved_apps, ->(aid_application) do
+    approved.matching_submitted_apps(aid_application)
+  end
+
   belongs_to :organization, counter_cache: true
   belongs_to :creator, class_name: 'User', inverse_of: :aid_applications_created, counter_cache: :aid_applications_created_count
   belongs_to :submitter, class_name: 'User', inverse_of: :aid_applications_submitted, counter_cache: :aid_applications_submitted_count, optional: :true

--- a/spec/models/aid_application_spec.rb
+++ b/spec/models/aid_application_spec.rb
@@ -295,6 +295,25 @@ RSpec.describe AidApplication, type: :model do
     end
   end
 
+  describe '.matching_approved_apps' do
+    context 'there are existing approved apps with the same name, birthday, zip code and street address' do
+      it 'returns the matching apps' do
+        name = "Fake Name"
+        birthday = 'January 1, 1980'
+        zip_code = '12345'
+        street_address = '123 Main St'
+        aid_application = create :aid_application, :submitted, name: name, birthday: birthday, zip_code: zip_code, street_address: street_address
+        duplicate_aid_application = create :aid_application, :approved, name: name, birthday: birthday, zip_code: zip_code, street_address: street_address
+        _unapproved_matching_aid_application = create :aid_application, :submitted, name: name, birthday: birthday, zip_code: zip_code, street_address: street_address
+        _approved_street_address_does_not_match_aid_application = create :aid_application, :approved, name: name, birthday: birthday, zip_code: zip_code, street_address: 'other street address'
+        _approved_name_does_not_match_aid_application = create :aid_application, :approved, name: 'different name', birthday: birthday, zip_code: zip_code, street_address: street_address
+        extra_white_space_in_fields_aid_application = create :aid_application, :approved, name: "#{name}    ", birthday: birthday, zip_code: "#{zip_code}       ", street_address: " #{street_address}"
+
+        expect(AidApplication.matching_approved_apps(aid_application)).to eq [duplicate_aid_application, extra_white_space_in_fields_aid_application]
+      end
+    end
+  end
+
   describe '#disburse' do
     let(:supervisor) { create :supervisor }
     let(:payment_card) { create :payment_card }

--- a/spec/system/deduplication_flow_spec.rb
+++ b/spec/system/deduplication_flow_spec.rb
@@ -26,4 +26,33 @@ RSpec.describe 'Deduplication flow', type: :system do
       expect(AidApplication.find_by(id: duplicate_app.id)).to be_nil
     end
   end
+
+  context 'on application approval' do
+    let!(:supervisor) { create :supervisor }
+    let!(:assister) { create :assister, organization: supervisor.organization }
+    let!(:approved_app) { create :aid_application, :approved, creator: assister, organization: supervisor.organization }
+    let!(:duplicate_app) { create :aid_application, :submitted, creator: assister, organization: supervisor.organization, name: approved_app.name, street_address: approved_app.street_address, zip_code: approved_app.zip_code, birthday: approved_app.birthday }
+
+    it 'shows the duplication page when approving a duplicate app' do
+      sign_in supervisor
+      visit root_path
+      click_on duplicate_app.application_number
+      click_on 'Determination'
+      click_on 'Approve and continue to disbursement'
+
+      expect(page).to have_content 'This applicant has been identified as a duplicate.'
+      expect(duplicate_app.reload.approved_at).to be_nil
+
+      click_on 'Go back'
+      expect(page).to have_content 'Applicant Information'
+
+      click_on 'Determination'
+      click_on 'Approve and continue to disbursement'
+
+      expect(page).to have_content 'This applicant has been identified as a duplicate.'
+      click_on 'Delete this application'
+      expect(page).to have_content 'Start a new application'
+      expect(AidApplication.find_by(id: duplicate_app.id)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
I'm reusing the existing deduplication page because the actions from that page are the same in both places