### PR TITLE
Guard against trying to re-submit already submitted apps in the controller update

### DIFF
--- a/app/controllers/aid_applications/applicants_controller.rb
+++ b/app/controllers/aid_applications/applicants_controller.rb
@@ -15,7 +15,7 @@ module AidApplications
 
       app_is_duplicate = AidApplication.matching_submitted_apps(@aid_application).any?
 
-      if params[:form_action] == 'submit' && !app_is_duplicate
+      if params[:form_action] == 'submit' && !app_is_duplicate && !@aid_application.submitted?
         @aid_application.save_and_submit(submitter: current_user)
 
         if @aid_application.errors.empty?


### PR DESCRIPTION
- we already were not updating the application_number, submitted_at and submitter because they are readonly once they are set
but we could try to regenerate an application number which would then be sent in error

Co-authored-by: Whitney Schaefer <whitney.schaefer@gmail.com>