### PR TITLE
Schedule cleaning up old unsubmitted applications and reset Heroku Demo

### DIFF
--- a/app/lib/aid_application_cleaner.rb
+++ b/app/lib/aid_application_cleaner.rb
@@ -1,0 +1,6 @@
+class AidApplicationCleaner
+  def delete_stale_and_unsubmitted
+    apps_to_delete = AidApplication.where(submitted_at: nil).where('created_at < ?', 1.day.ago)
+    apps_to_delete.destroy_all
+  end
+end

--- a/bin/scheduler
+++ b/bin/scheduler
@@ -10,4 +10,11 @@ scheduler.every ENV.fetch('SEARCH_REFRESH_INTERVAL', '1m'), overlap: false do
   AidApplicationSearch.refresh
 end
 
+# every day at 2am
+scheduler.every '0 2 * * *' do
+  puts '=== deleting unsubmitted aid applications that are at least 24 hours old ==='
+  cleaner = AidApplicationCleaner.new
+  cleaner.delete_stale_and_unsubmitted
+end
+
 scheduler.join

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -13,4 +13,19 @@ namespace :heroku do
     Rake::Task['db:schema:load'].invoke
     Rake::Task['db:seed'].invoke
   end
+
+  desc "Heroku drop tables and reload schema and seeds (schedule to run every night on demo)"
+  task db_reset: :environment do
+    raise "Cannot run this task in production" if Rails.env.production?
+
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if table.in? ['schema_migrations', 'ar_internal_metadata']
+
+      query = "DROP TABLE IF EXISTS #{table} CASCADE;"
+      ActiveRecord::Base.connection.execute(query)
+    end
+
+    Rake::Task['db:schema:load'].invoke
+    Rake::Task['db:seed'].invoke
+  end
 end

--- a/spec/lib/aid_application_cleaner_spec.rb
+++ b/spec/lib/aid_application_cleaner_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe AidApplicationCleaner do
+  describe '#delete_stale_and_unsubmitted' do
+    it 'deletes unsubmitted aid applications that are more than 24 hours old' do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+
+      submitted_application = create :aid_application, :submitted
+      approved_application = create :aid_application, :approved
+      disbursed_application = create :aid_application, :disbursed
+      recent_application = create :aid_application, created_at: 1.hour.ago
+      _old_unsubmitted_application = create :aid_application, created_at: 25.hour.ago
+      AidApplicationCleaner.new.delete_stale_and_unsubmitted
+
+      expect(AidApplication.all).to eq [submitted_application, approved_application, disbursed_application, recent_application]
+    end
+  end
+end


### PR DESCRIPTION
- on production delete unsubmitted apps that are more than 24 hours old every night at 2am
- on demo delete all apps every night at 2am