### PR TITLE
Remove explicit master ref from Github Action deploy step

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: master
           fetch-depth: 0
 
       - name: Setup SSH Keys and known_hosts


### PR DESCRIPTION
I think this explicit `master` branch reference is what causes simultaneous merges to sometimes fail on deploy. I think what is happening currently is:

1. Merge PR A. Merge Commit A starts running tests
2. Merge PR B. Merge Commit B starts running tests
3. Merge Commit A starts deploy and checks out `master` which is now includes code from Merge PR B. It blocks until finished
4. Merge Commit B starts deploying but Aptible rejects it because it says that commit has already been deployed.

By removing the explicit ref from the Github Actions param, I hope that instead deploys will deploy what was merged into master.