### PR TITLE
Add sequence number confirmation input field

### DIFF
--- a/app/controllers/aid_applications/disbursements_controller.rb
+++ b/app/controllers/aid_applications/disbursements_controller.rb
@@ -28,6 +28,10 @@ module AidApplications
         @search_card.errors.add(:sequence_number, t('activerecord.errors.messages.sequence_number_already_assigned'))
       end
 
+      unless @search_card.matching_sequence_numbers?
+        @search_card.errors.add(:sequence_number_confirmation, t('activerecord.errors.messages.sequence_numbers_must_match'))
+      end
+
       if @search_card.errors.any?
         render :edit
         return
@@ -51,7 +55,7 @@ module AidApplications
     private
 
     def search_card_params
-      params.require(:search_card).permit(:sequence_number).except(:aid_application)
+      params.require(:search_card).permit(:sequence_number, :sequence_number_confirmation).except(:aid_application)
     end
 
     def aid_application_params
@@ -61,9 +65,14 @@ module AidApplications
     class SearchCard
       include ActiveModel::Model
       attr_accessor :sequence_number
+      attr_accessor :sequence_number_confirmation
 
       def self.model_name
         ActiveModel::Name.new(self, nil, "SearchCard")
+      end
+
+      def matching_sequence_numbers?
+        (sequence_number.presence || '').strip == (sequence_number_confirmation.presence || '').strip
       end
     end
   end

--- a/app/views/aid_applications/disbursements/edit.html.erb
+++ b/app/views/aid_applications/disbursements/edit.html.erb
@@ -16,6 +16,8 @@
       <div class="form-card__content">
         <%= f.cfa_input_field :sequence_number, t('.sequence_number') %>
 
+        <%= f.cfa_input_field :sequence_number_confirmation, t('.sequence_number_confirmation') %>
+
         <div class="accordion">
           <button class="accordion__button" aria-expanded="true" aria-controls="about_program"><%= t('.sequence_number_help') %></button>
           <div class="accordion__content" id="about_program">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
         required_question: This question is required.
         sequence_number_already_assigned: This sequence number has already been used.
         sequence_number_invalid: Make sure the sequence number is correct.
+        sequence_numbers_must_match: Make sure these numbers match.
         zip_code: Must be a 5-digit ZIP Code in California.
         zip_code_outside_organization_service_area: "%{zip_code} is in %{zip_code_county},
           which is outside of your organization's service area. Please update the
@@ -267,6 +268,7 @@ en:
         method: What method was the card disbursed by?
         print_signature: Print Signature Page
         sequence_number: Card Sequence Number
+        sequence_number_confirmation: Type card sequence number again
         sequence_number_help: Where to find the card sequence number
         title: Disburse card
         when: When was the card disbursed?

--- a/spec/controllers/aid_applications/disbursements_controller_spec.rb
+++ b/spec/controllers/aid_applications/disbursements_controller_spec.rb
@@ -44,6 +44,7 @@ describe AidApplications::DisbursementsController do
         aid_application_id: aid_application.id,
         search_card: {
           sequence_number: payment_card.sequence_number,
+          sequence_number_confirmation: payment_card.sequence_number,
           aid_application: {
             card_receipt_method: 'mail'
           }

--- a/spec/system/approve_aid_application_spec.rb
+++ b/spec/system/approve_aid_application_spec.rb
@@ -66,12 +66,14 @@ describe 'Approve aid application', type: :system do
     expect(aid_application.approved_at).to be_within(2.seconds).of(Time.current)
     expect(aid_application.approver).to eq supervisor
 
-    fill_in I18n.t('aid_applications.disbursements.edit.sequence_number'), with: "garbage"
+    fill_in I18n.t('aid_applications.disbursements.edit.sequence_number'), with: "garbage", match: :first
     click_on I18n.t('aid_applications.disbursements.edit.disburse_card')
 
     expect(page).to have_content I18n.t('activerecord.errors.messages.sequence_number_invalid')
+    expect(page).to have_content I18n.t('activerecord.errors.messages.sequence_numbers_must_match')
 
     fill_in I18n.t('aid_applications.disbursements.edit.sequence_number'), with: payment_card.sequence_number
+    fill_in I18n.t('aid_applications.disbursements.edit.sequence_number_confirmation'), with: payment_card.sequence_number
     click_on I18n.t('aid_applications.disbursements.edit.disburse_card')
 
     expect(page).to have_content "Card successfully disbursed"


### PR DESCRIPTION
* validation checks for a match and checks that the field is filled in
* Also, decided against using [this pattern](https://guides.rubyonrails.org/active_record_validations.html#message) because it relies on database validations, which are not accessible with the `SearchCard` model. Instead, I followed the established pattern for validating sequence numbers