### PR TITLE
When showing waitlist notice, defer to Organization#using_waitlist? only when application is unsubmitted

### DIFF
--- a/app/views/aid_applications/eligibilities/edit.html.erb
+++ b/app/views/aid_applications/eligibilities/edit.html.erb
@@ -16,7 +16,7 @@
         </div>
         <hr>
 
-        <% if current_organization.using_waitlist? %>
+        <% if (!@aid_application.submitted? && current_organization.using_waitlist?) || @aid_application.waitlisted? %>
           <p class="notice notice--error">
             <strong>Application is waitlisted</strong>: Explain to the client that they are on a waitlist and may not get a card.
           </p>


### PR DESCRIPTION
I think when I did this in #259 I didn't think through that the Eligibility screen would be visible after an application is submitted.